### PR TITLE
feat(widy): 위디(Widy) 피드 기능 및 CRUD API 구현

### DIFF
--- a/src/main/java/com/example/ieumapi/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/example/ieumapi/group/repository/GroupMemberRepository.java
@@ -4,8 +4,10 @@ import com.example.ieumapi.group.domain.Group;
 import com.example.ieumapi.group.domain.GroupMember;
 import com.example.ieumapi.group.domain.GroupMemberId;
 import com.example.ieumapi.user.domain.User;
+import feign.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -30,4 +32,12 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, GroupM
     void deleteByGroupGroupIdAndUserId(Long groupId, Long userId);
 
     long countByGroupGroupId(Long groupId);
+
+    /**
+     * 특정 사용자가 속한 모든 그룹의 ID를 가입일 내림차순으로 조회합니다.
+     * @param user 조회할 사용자
+     * @return 그룹 ID 리스트
+     */
+    @Query("SELECT gm.groupId FROM GroupMember gm WHERE gm.user = :user ORDER BY gm.joinedAt DESC")
+    List<Long> findGroupIdsByUserOrderByJoinedAtDesc(@Param("user") User user);
 }

--- a/src/main/java/com/example/ieumapi/group/service/GroupService.java
+++ b/src/main/java/com/example/ieumapi/group/service/GroupService.java
@@ -315,4 +315,23 @@ public class GroupService {
 
         groupMemberRepository.deleteByGroupGroupIdAndUserId(groupId, currentUserId);
     }
+
+
+    /**
+     * 현재 인증된 사용자가 속한 모든 그룹 목록을 조회합니다.
+     * <p>
+     * 이 메소드는 페이지네이션 없이 사용자가 가입한 모든 그룹의 목록을 반환합니다.
+     * 결과는 가입한 시각(joinedAt)을 기준으로 내림차순 정렬됩니다.
+     *
+     * @return 사용자가 속한 그룹 정보(GroupDto)가 담긴 리스트
+     * @throws GroupException 사용자를 찾을 수 없는 경우 (UNAUTHORIZED)
+     */
+    @Transactional(readOnly = true)
+    public List<Long> getMyGroups() {
+        Long currentUserId = SecurityUtils.getCurrentUserId();
+        User currentUser = userRepository.findById(currentUserId)
+            .orElseThrow(() -> new GroupException(GroupError.UNAUTHORIZED));
+
+        return groupMemberRepository.findGroupIdsByUserOrderByJoinedAtDesc(currentUser);
+    }
 }

--- a/src/main/java/com/example/ieumapi/widy/controller/WidyController.java
+++ b/src/main/java/com/example/ieumapi/widy/controller/WidyController.java
@@ -1,14 +1,20 @@
 package com.example.ieumapi.widy.controller;
 
+import com.example.ieumapi.global.response.CursorPageResponse;
+import com.example.ieumapi.global.util.SecurityUtils;
 import com.example.ieumapi.widy.dto.*;
 import com.example.ieumapi.widy.service.WidyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.util.List;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Tag(name = "Widy", description = "Widy 관련 API")
 @RestController
@@ -19,7 +25,7 @@ public class WidyController {
 
     @Operation(summary = "Widy 생성", description = "새로운 Widy를 생성합니다.")
     @PostMapping()
-    public ResponseEntity<WidyResponseDto> create(@RequestPart("widy") WidyCreateRequestDto request
+    public ResponseEntity<WidyResponseDto> create(@RequestPart("widy") @Valid WidyCreateRequestDto request
     , @RequestPart(value = "images", required = false) List<MultipartFile> images) {
         WidyResponseDto widyResponseDto = widyService.createWidy(request, images);
         return ResponseEntity.ok(widyResponseDto);
@@ -31,15 +37,17 @@ public class WidyController {
         return ResponseEntity.ok(widyService.getWidy(id));
     }
 
-    @Operation(summary = "사용자별 Widy 조회", description = "특정 사용자가 작성한 모든 Widy를 조회합니다.")
-    @GetMapping
-    public ResponseEntity<List<WidyResponseDto>> getByUserId(@RequestParam Long userId) {
-        return ResponseEntity.ok(widyService.getByUserId(userId));
+    @Operation(summary = "내 Widy 목록 조회", description = "현재 로그인한 사용자가 작성한 모든 Widy를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<List<WidyResponseDto>> getMyWidys() {
+        return ResponseEntity.ok(widyService.getByUserId());
     }
 
-    @Operation(summary = "Widy 수정", description = "기존 Widy를 수정합니다.")
+    @Operation(summary = "Widy 수정", description = "기존 Widy를 수정합니다. 본인만 수정할 수 있습니다.")
     @PatchMapping("/{id}")
-    public ResponseEntity<WidyResponseDto> update(@PathVariable Long id, @RequestBody WidyUpdateRequestDto dto) {
+    public ResponseEntity<WidyResponseDto> update(
+        @PathVariable Long id,
+        @RequestBody @Valid WidyUpdateRequestDto dto) {
         return ResponseEntity.ok(widyService.update(id, dto));
     }
 
@@ -49,5 +57,22 @@ public class WidyController {
         widyService.delete(id);
         return ResponseEntity.noContent().build();
     }
-}
 
+    @Operation(summary = "공개 Widy 조회", description = "공개된 모든 Widy를 최신순으로 조회합니다.")
+    @GetMapping("/public")
+    public ResponseEntity<CursorPageResponse<WidyResponseDto>> getPublicWidys(
+        @RequestParam(defaultValue = "10") @Min(1) @Max(50) int size,
+        @RequestParam(required = false) String cursor
+    ) {
+        return ResponseEntity.ok(widyService.getPublicWidysCursor(size, cursor));
+    }
+
+    @Operation(summary = "그룹 피드 조회", description = "사용자가 속한 그룹의 모든 Widy를 최신순으로 조회합니다.")
+    @GetMapping("/feed")
+    public ResponseEntity<CursorPageResponse<WidyResponseDto>> getGroupFeed(
+        @RequestParam(defaultValue = "10") @Min(1) @Max(50) int size,
+        @RequestParam(required = false) String cursor
+    ) {
+        return ResponseEntity.ok(widyService.getGroupFeedCursor(size, cursor));
+    }
+}

--- a/src/main/java/com/example/ieumapi/widy/domain/Widy.java
+++ b/src/main/java/com/example/ieumapi/widy/domain/Widy.java
@@ -28,6 +28,9 @@ public class Widy extends BaseEntity {
     private Long userId;
     private LocalDate date;
 
+    @Enumerated(EnumType.STRING)
+    private WidyScope scope;
+
     @ElementCollection
     @Enumerated(EnumType.STRING)
     @CollectionTable(

--- a/src/main/java/com/example/ieumapi/widy/domain/WidyEmotion.java
+++ b/src/main/java/com/example/ieumapi/widy/domain/WidyEmotion.java
@@ -1,16 +1,37 @@
 package com.example.ieumapi.widy.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(enumAsRef = true)
 public enum WidyEmotion {
-    HAPPY,      // 0: 기쁨
-    SAD,        // 1: 슬픔
-    ANGRY,      // 2: 분노
-    EXCITED,    // 3: 신남
-    CALM,       // 4: 차분함
-    NERVOUS,    // 5: 긴장
-    BORED,      // 6: 지루함
-    SURPRISED,  // 7: 놀람
-    TIRED,      // 8: 피곤함
-    PROUD       // 9: 뿌듯함
+    SENSITIVITY("감성"),
+    TASTY_PLACE("맛집"),
+    SCENIC_PLACE("뷰맛집"),
+    OVERWHELMED("압도"),
+    SPONTANEOUS("즉흥"),
+    EXCITED("신남"),
+    HEALING("힐링");
+
+    private final String value;
+
+    WidyEmotion(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static WidyEmotion from(String value) {
+        for (WidyEmotion emotion : WidyEmotion.values()) {
+            if (emotion.getValue().equals(value)) {
+                return emotion;
+            }
+        }
+        return null;
+    }
 }
-// ordinal() 값이 0부터 시작하며, 위 순서대로 0~9의 값을 가집니다.
-// 예시: WidyEmotion.HAPPY.ordinal() == 0, WidyEmotion.SAD.ordinal() == 1, ...

--- a/src/main/java/com/example/ieumapi/widy/domain/WidyScope.java
+++ b/src/main/java/com/example/ieumapi/widy/domain/WidyScope.java
@@ -1,0 +1,8 @@
+package com.example.ieumapi.widy.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(enumAsRef = true)
+public enum WidyScope {
+    PRIVATE, GROUP, PUBLIC
+}

--- a/src/main/java/com/example/ieumapi/widy/dto/WidyCreateRequestDto.java
+++ b/src/main/java/com/example/ieumapi/widy/dto/WidyCreateRequestDto.java
@@ -2,25 +2,44 @@ package com.example.ieumapi.widy.dto;
 
 import com.example.ieumapi.widy.domain.Widy;
 import com.example.ieumapi.widy.domain.WidyEmotion;
-import com.example.ieumapi.widy.domain.WidyImage;
+import com.example.ieumapi.widy.domain.WidyScope;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.Set;
 import lombok.Getter;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 @Getter
 public class WidyCreateRequestDto {
+    @Schema(description = "사용자 ID", example = "1")
     @NotNull
     private Long userId;
+
+    @Schema(description = "위디 제목", example = "오늘의 맛집 탐방")
     @NotBlank
     private String title;
+
+    @Schema(description = "위디 내용", example = "오늘은 강남역 근처 맛집에 다녀왔다. 너무 맛있었다!")
     @NotBlank
     private String content;
+
+    @Schema(description = "일정 ID", example = "10")
     private Long scheduleId;
+
+    @Schema(description = "그룹 ID (scope가 GROUP일 경우 필수)", example = "5")
     private Long groupId;
+
+    @Schema(description = "날짜", example = "2024-07-24")
     private LocalDate date;
+
+    @Schema(description = "감정 목록", example = "[맛집, 신남]")
+    @NotEmpty
     private Set<WidyEmotion> emotions;
+
+    @Schema(description = "공개 범위", example = "PUBLIC")
+    private WidyScope scope;
 
     public Widy toEntity() {
         return Widy.builder()
@@ -31,7 +50,7 @@ public class WidyCreateRequestDto {
             .groupId(groupId)
             .date(date)
             .widyEmotionList(emotions)
+            .scope(scope)
             .build();
     }
 }
-

--- a/src/main/java/com/example/ieumapi/widy/dto/WidyUpdateRequestDto.java
+++ b/src/main/java/com/example/ieumapi/widy/dto/WidyUpdateRequestDto.java
@@ -1,6 +1,10 @@
 package com.example.ieumapi.widy.dto;
 
+import com.example.ieumapi.widy.domain.WidyEmotion;
+import com.example.ieumapi.widy.domain.WidyScope;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.Builder;
@@ -14,12 +18,27 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class WidyUpdateRequestDto {
+    @Schema(description = "위디 제목", example = "수정된 맛집 탐방")
     private String title;
-    private String content;
-    private Long scheduleId;
-    private Long groupId;
-    private LocalDate date;
-    private Long photoId;
-    private java.util.Set<com.example.ieumapi.widy.domain.WidyEmotion> emotions;
-}
 
+    @Schema(description = "위디 내용", example = "사실은 맛집이 아니었다.")
+    private String content;
+
+    @Schema(description = "일정 ID", example = "11")
+    private Long scheduleId;
+
+    @Schema(description = "그룹 ID (scope가 GROUP일 경우 필수)", example = "6")
+    private Long groupId;
+
+    @Schema(description = "날짜", example = "2024-07-25")
+    private LocalDate date;
+
+    @Schema(description = "사진 ID", example = "2")
+    private Long photoId;
+
+    @Schema(description = "감정 목록", example = "[힐링, 즉흥]")
+    private Set<WidyEmotion> emotions;
+
+    @Schema(description = "공개 범위", example = "GROUP")
+    private WidyScope scope;
+}

--- a/src/main/java/com/example/ieumapi/widy/exception/WidyErrorCode.java
+++ b/src/main/java/com/example/ieumapi/widy/exception/WidyErrorCode.java
@@ -1,0 +1,37 @@
+package com.example.ieumapi.widy.exception;
+
+import com.example.ieumapi.global.exception.CustomError;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum WidyErrorCode implements CustomError {
+    WIDY_NOT_FOUND("WIDY_001", "위디를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    GROUP_ID_REQUIRED("WIDY_002", "GROUP scope에는 Group ID가 필수입니다.", HttpStatus.BAD_REQUEST),
+    FORBIDDEN("WIDY_003", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    WidyErrorCode(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/example/ieumapi/widy/exception/WidyException.java
+++ b/src/main/java/com/example/ieumapi/widy/exception/WidyException.java
@@ -1,43 +1,10 @@
 package com.example.ieumapi.widy.exception;
 
 import com.example.ieumapi.global.exception.CustomBaseException;
-import com.example.ieumapi.global.exception.CustomError;
-import org.springframework.http.HttpStatus;
 
 public class WidyException extends CustomBaseException {
 
-    public WidyException(WidyError error) {
-        super(error);
-    }
-
-    public enum WidyError implements CustomError {
-        WIDY_NOT_FOUND("WIDY_001", "Widy를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-        INVALID_EMOTION("WIDY_002", "유효하지 않은 감정 값입니다.", HttpStatus.BAD_REQUEST),
-        IMAGE_UPLOAD_FAILED("WIDY_003", "이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
-
-        private final String code;
-        private final String message;
-        private final HttpStatus status;
-
-        WidyError(String code, String message, HttpStatus status) {
-            this.code = code;
-            this.message = message;
-            this.status = status;
-        }
-
-        @Override
-        public String getCode() {
-            return code;
-        }
-
-        @Override
-        public String getMessage() {
-            return message;
-        }
-
-        @Override
-        public HttpStatus getStatus() {
-            return status;
-        }
+    public WidyException(WidyErrorCode widyErrorCode) {
+        super(widyErrorCode);
     }
 }

--- a/src/main/java/com/example/ieumapi/widy/repository/WidyImageRepository.java
+++ b/src/main/java/com/example/ieumapi/widy/repository/WidyImageRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WidyImageRepository extends JpaRepository<WidyImage, Long> {
     List<WidyImage> findByWidyId(Long widyId);
+
+    List<WidyImage> findByWidyIdIn(List<Long> widyIds);
 }

--- a/src/main/java/com/example/ieumapi/widy/repository/WidyRepository.java
+++ b/src/main/java/com/example/ieumapi/widy/repository/WidyRepository.java
@@ -1,10 +1,15 @@
 package com.example.ieumapi.widy.repository;
 
 import com.example.ieumapi.widy.domain.Widy;
+import com.example.ieumapi.widy.domain.WidyScope;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface WidyRepository extends JpaRepository<Widy, Long> {
     List<Widy> findByUserId(Long userId);
+    List<Widy> findByScopeAndCreatedAtLessThanOrderByCreatedAtDesc(WidyScope scope, LocalDateTime createdAt, Pageable pageable);
+    List<Widy> findByGroupIdInAndCreatedAtLessThanOrderByCreatedAtDesc(List<Long> groupIds, LocalDateTime createdAt, Pageable pageable);
 }
-

--- a/src/main/java/com/example/ieumapi/widy/service/WidyService.java
+++ b/src/main/java/com/example/ieumapi/widy/service/WidyService.java
@@ -2,19 +2,37 @@ package com.example.ieumapi.widy.service;
 
 import com.example.ieumapi.file.FileStorageClient;
 import com.example.ieumapi.file.dto.UploadImageResDto;
+import com.example.ieumapi.global.response.CursorPageResponse;
+import com.example.ieumapi.global.util.SecurityUtils;
+import com.example.ieumapi.group.service.GroupService;
 import com.example.ieumapi.widy.domain.Widy;
 import com.example.ieumapi.widy.domain.WidyImage;
+import com.example.ieumapi.widy.domain.WidyScope;
 import com.example.ieumapi.widy.dto.WidyCreateRequestDto;
 import com.example.ieumapi.widy.dto.WidyResponseDto;
 import com.example.ieumapi.widy.dto.WidyUpdateRequestDto;
+import com.example.ieumapi.widy.exception.WidyErrorCode;
+import com.example.ieumapi.widy.exception.WidyException;
 import com.example.ieumapi.widy.repository.WidyImageRepository;
 import com.example.ieumapi.widy.repository.WidyRepository;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -23,9 +41,15 @@ public class WidyService {
 
     private final WidyRepository widyRepository;
     private final WidyImageRepository widyImageRepository;
+    private final GroupService groupService;
     private final FileStorageClient fileStorageClient;
 
     public WidyResponseDto createWidy(WidyCreateRequestDto requestDto, List<MultipartFile> images) {
+        // Scope validation
+        if (requestDto.getScope() == WidyScope.GROUP && requestDto.getGroupId() == null) {
+            throw new WidyException(WidyErrorCode.GROUP_ID_REQUIRED);
+        }
+
         // 1. Widy 엔티티 생성 및 저장
         Widy widy = requestDto.toEntity();
         Widy savedWidy = widyRepository.save(widy);
@@ -55,10 +79,51 @@ public class WidyService {
             .build();
     }
 
+    public WidyResponseDto update(Long id, WidyUpdateRequestDto dto) {
+        Widy widy = widyRepository.findById(id)
+            .orElseThrow(() -> new WidyException(WidyErrorCode.WIDY_NOT_FOUND));
+
+        Long userId = SecurityUtils.getCurrentUserId();
+        if (!widy.getUserId().equals(userId)) {
+            throw new WidyException(WidyErrorCode.FORBIDDEN);
+        }
+
+        // Scope validation
+        if (dto.getScope() == WidyScope.GROUP && dto.getGroupId() == null) {
+            throw new WidyException(WidyErrorCode.GROUP_ID_REQUIRED);
+        }
+
+        widy.update(dto.getTitle(), dto.getContent());
+        // DB에서 이미지를 다시 조회하는 헬퍼 메소드 호출
+        return mapToWidyResponseDto(widy);
+    }
+
+    public void delete(Long id) {
+        Widy widy = widyRepository.findById(id)
+            .orElseThrow(() -> new WidyException(WidyErrorCode.WIDY_NOT_FOUND));
+
+        Long userId = SecurityUtils.getCurrentUserId();
+        if (!widy.getUserId().equals(userId)) {
+            throw new WidyException(WidyErrorCode.FORBIDDEN);
+        }
+
+        widyRepository.deleteById(id);
+    }
+
     @Transactional(readOnly = true)
     public WidyResponseDto getWidy(Long widyId) {
         Widy widy = widyRepository.findById(widyId)
-            .orElseThrow(() -> new IllegalArgumentException("Widy not found"));
+            .orElseThrow(() -> new WidyException(WidyErrorCode.WIDY_NOT_FOUND));
+
+        Long userId = SecurityUtils.getCurrentUserId();
+
+        // Access control based on scope
+        if (widy.getScope() == WidyScope.PRIVATE && !widy.getUserId().equals(userId)) {
+            throw new WidyException(WidyErrorCode.FORBIDDEN);
+        }
+        if (widy.getScope() == WidyScope.GROUP && !groupService.getMyGroups().contains(widy.getGroupId())) { // Assuming getGroupIdForUser is a method that retrieves the group ID for a user
+            throw new WidyException(WidyErrorCode.FORBIDDEN);
+        }
 
         List<WidyImage> widyImages = widyImageRepository.findByWidyId(widyId);
 
@@ -80,27 +145,164 @@ public class WidyService {
     }
 
     @Transactional(readOnly = true)
-    public List<WidyResponseDto> getByUserId(Long userId) {
+    public List<WidyResponseDto> getByUserId() {
+
+        Long userId = SecurityUtils.getCurrentUserId();
+        // 1. 사용자의 모든 Widy를 조회
         List<Widy> widys = widyRepository.findByUserId(userId);
+        if (widys.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 2. Widy ID 목록 추출
+        List<Long> widyIds = widys.stream()
+            .map(Widy::getWidyId)
+            .collect(Collectors.toList());
+
+        // 3. 모든 관련 이미지를 한 번의 쿼리로 조회 후, Widy ID별로 그룹핑
+        Map<Long, List<WidyImage>> imagesByWidyId = widyImageRepository.findByWidyIdIn(widyIds).stream()
+            .collect(Collectors.groupingBy(WidyImage::getWidyId));
+
+        // 4. DTO로 변환 (DB 추가 조회 없음)
         return widys.stream()
-            .map(this::mapToWidyResponseDto)
+            .map(widy -> {
+                List<WidyImage> images = imagesByWidyId.getOrDefault(widy.getWidyId(), Collections.emptyList());
+                return mapToWidyResponseDto(widy, images);
+            })
             .collect(Collectors.toList());
     }
 
-    public WidyResponseDto update(Long id, WidyUpdateRequestDto dto) {
-        Widy widy = widyRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("Widy not found"));
-        widy.update(dto.getTitle(), dto.getContent());
-        return mapToWidyResponseDto(widy);
+    @Transactional(readOnly = true)
+    public CursorPageResponse<WidyResponseDto> getPublicWidysCursor(int size, String cursor) {
+        // 1. 커서 디코딩 및 페이지 정보 설정
+        long cursorMillis = decodeCursor(cursor); // 이제 이 메소드를 찾을 수 있습니다.
+        LocalDateTime cursorTime = (cursorMillis <= 0)
+            ? LocalDateTime.now()
+            : LocalDateTime.ofInstant(Instant.ofEpochMilli(cursorMillis), ZoneOffset.UTC);
+
+        Pageable pageable = PageRequest.of(0, size + 1, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<Widy> widys = widyRepository
+            .findByScopeAndCreatedAtLessThanOrderByCreatedAtDesc(WidyScope.PUBLIC, cursorTime, pageable);
+
+        boolean hasNext = widys.size() > size;
+        if (hasNext) {
+            widys = widys.subList(0, size);
+        }
+
+        // --- N+1 문제 해결을 위한 최적화 로직 (기존과 동일) ---
+        List<Long> widyIds = widys.stream()
+            .map(Widy::getWidyId)
+            .collect(Collectors.toList());
+
+        Map<Long, List<WidyImage>> imagesByWidyId = widyIds.isEmpty()
+            ? Collections.emptyMap()
+            : widyImageRepository.findByWidyIdIn(widyIds).stream()
+                .collect(Collectors.groupingBy(WidyImage::getWidyId));
+
+        List<WidyResponseDto> data = widys.stream()
+            .map(widy -> {
+                List<WidyImage> widyImages = imagesByWidyId.getOrDefault(widy.getWidyId(), Collections.emptyList());
+                return mapToWidyResponseDto(widy, widyImages);
+            })
+            .collect(Collectors.toList());
+
+        // --- 다음 커서 생성 (기존과 동일) ---
+        String nextCursor = null;
+        if (hasNext) {
+            long lastMillis = widys.get(widys.size() - 1)
+                .getCreatedAt().toInstant(ZoneOffset.UTC).toEpochMilli();
+            nextCursor = Base64.getEncoder()
+                .encodeToString(String.valueOf(lastMillis).getBytes(StandardCharsets.UTF_8));
+        }
+
+        return new CursorPageResponse<>(data, nextCursor, hasNext);
     }
 
-    public void delete(Long id) {
-        widyRepository.deleteById(id);
+    @Transactional(readOnly = true)
+    public CursorPageResponse<WidyResponseDto> getGroupFeedCursor(int size, String cursor) {
+
+        // 1. 사용자가 속한 그룹 ID 목록 가져오기
+        List<Long> groupIds = groupService.getMyGroups();
+
+        // 2. 만약 사용자가 속한 그룹이 하나도 없다면, 비어있는 페이지 반환
+        if (groupIds.isEmpty()) {
+            return new CursorPageResponse<>(Collections.emptyList(), null, false);
+        }
+
+        // 3. 커서 디코딩 및 페이지 정보 설정
+        long cursorMillis = decodeCursor(cursor);
+        LocalDateTime cursorTime = (cursorMillis <= 0)
+            ? LocalDateTime.now()
+            : LocalDateTime.ofInstant(Instant.ofEpochMilli(cursorMillis), ZoneOffset.UTC);
+
+        Pageable pageable = PageRequest.of(0, size + 1, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<Widy> widys = widyRepository
+            .findByGroupIdInAndCreatedAtLessThanOrderByCreatedAtDesc(groupIds, cursorTime, pageable);
+
+        boolean hasNext = widys.size() > size;
+        if (hasNext) {
+            widys = widys.subList(0, size);
+        }
+
+        // 5. N+1 문제 해결을 위한 최적화 로직
+        List<Long> widyIds = widys.stream()
+            .map(Widy::getWidyId)
+            .collect(Collectors.toList());
+
+        Map<Long, List<WidyImage>> imagesByWidyId = widyIds.isEmpty()
+            ? Collections.emptyMap()
+            : widyImageRepository.findByWidyIdIn(widyIds).stream()
+                .collect(Collectors.groupingBy(WidyImage::getWidyId));
+
+        List<WidyResponseDto> data = widys.stream()
+            .map(widy -> {
+                List<WidyImage> widyImages = imagesByWidyId.getOrDefault(widy.getWidyId(), Collections.emptyList());
+                return mapToWidyResponseDto(widy, widyImages);
+            })
+            .collect(Collectors.toList());
+
+        // 6. 다음 커서 생성
+        String nextCursor = null;
+        if (hasNext) {
+            long lastMillis = widys.get(widys.size() - 1)
+                .getCreatedAt().toInstant(ZoneOffset.UTC).toEpochMilli();
+            nextCursor = Base64.getEncoder()
+                .encodeToString(String.valueOf(lastMillis).getBytes(StandardCharsets.UTF_8));
+        }
+
+        return new CursorPageResponse<>(data, nextCursor, hasNext);
     }
 
+    // ==================== 추가된 헬퍼 메소드들 ====================
+
+    /**
+     * Base64로 인코딩된 커서 문자열을 디코딩하여 long 타입의 시간(ms)으로 변환합니다.
+     */
+    private long decodeCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) return 0L;
+        try {
+            String decoded = new String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8);
+            return Long.parseLong(decoded);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "cursor 형식이 잘못되었습니다.");
+        }
+    }
+
+    /**
+     * Widy 엔티티를 받아 이미지를 조회한 후 DTO로 변환하는 헬퍼 메소드.
+     * 단일 Widy를 조회하는 경우에 사용됩니다.
+     */
     private WidyResponseDto mapToWidyResponseDto(Widy widy) {
-        List<WidyImage> widyImages = widyImageRepository.findByWidyId(widy.getWidyId());
-        List<UploadImageResDto> imageDtos = widyImages.stream()
+        List<WidyImage> images = widyImageRepository.findByWidyId(widy.getWidyId());
+        return mapToWidyResponseDto(widy, images);
+    }
+
+    /**
+     * Widy 엔티티와 이미지 목록을 받아 DTO로 변환하는 헬퍼 메소드.
+     * DB 조회를 하지 않으므로 N+1 문제 해결에 사용됩니다.
+     */
+    private WidyResponseDto mapToWidyResponseDto(Widy widy, List<WidyImage> images) {
+        List<UploadImageResDto> imageDtos = images.stream()
             .map(image -> UploadImageResDto.builder()
                 .id(image.getId())
                 .originalName(image.getOriginalName())


### PR DESCRIPTION
사용자가 게시물을 작성하고 공유할 수 있는 위디(Widy) 기능의 핵심 API를 구현했습니다. 공개 피드와 사용자가 속한 그룹의 게시물만 모아보는 그룹 피드 기능을 추가하여 사용자 경험을 개선했습니다.

주요 변경 사항:
- **Widy CRUD API 구현**:
  - `POST /api/v1/widy`: 위디 생성 (이미지 포함)
  - `GET /api/v1/widy/{id}`: 위디 단건 조회
  - `GET /api/v1/widy/me`: 내 위디 목록 조회
  - `PATCH /api/v1/widy/{id}`: 위디 수정
  - `DELETE /api/v1/widy/{id}`: 위디 삭제

- **피드 기능 구현 (커서 기반 페이지네이션):**
  - `GET /api/v1/widy/public`: 공개된 모든 위디를 최신순으로 조회합니다.
  - `GET /api/v1/widy/feed`: 사용자가 속한 그룹의 모든 위디를 최신순으로 조회합니다.

- **성능 및 보안 개선:**
  - **N+1 문제 해결**: 위디 목록 조회 시, 연관된 이미지를 한 번의 쿼리로 가져오도록 최적화하여 DB 부하를 줄였습니다.
  - **보안 강화**: 수정 및 삭제 API에서 `userId`를 파라미터로 받지 않고, Security Context의 인증된 사용자 정보를 사용하도록 변경하여 안정성을 높였습니다.