### PR TITLE
fix : widy 단건 조회시, widy를 작성한 user의 이메일 값이 아닌 현재 접속한 user의 이메일 반환됨

### DIFF
--- a/src/main/java/com/example/ieumapi/user/service/UserService.java
+++ b/src/main/java/com/example/ieumapi/user/service/UserService.java
@@ -137,4 +137,9 @@ public class UserService {
             throw new UserException(INVALID_CURSOR);
         }
     }
+
+    public User getUserInfo(long userId){
+       return userRepository.findByUserId(userId)
+            .orElseThrow(() -> new UserException(INVALID_CREDENTIALS));
+    }
 }


### PR DESCRIPTION
### 💡 개요
<!-- "어떻게보다 무엇을 왜" 라는 좋은 가이드를 더 잘 표현하기 위해, 변경 전후(As-is & To-be) 형식으로 작성하는 것을 추천드러요!!-->
 AS - IS : widy 단건 조회시, widy를 작성한 user의 이메일 값이 아닌 현재 접속한 user의 이메일 반환됨
 TO - BE : widy 단건 조회시, widy를 작성한 user의 이메일 값이 반환됨

### 🔗 관련 이슈
<!-- PR이 머지될 때 이슈가 자동으로 닫혀요!! -->
Close #46 


### 📝 작업 내용
<!-- 무슨 작업을 진행하셨나요? -->
- UserService에 getUserInfo 메소드를 정의
- widy 단건 조회 시, 해당 메소드를 통해 widy를 작성한 사람의 이메일값을 반환


### ✔️ PR Checklist
<!--PR을 올리기 전, 아래 항목들을 모두 확인했는지 체크해주세요." -->
- [ ] 변경 사항에 대한 테스트를 진행했습니다.
- [ ] 관련 문서를 업데이트했습니다. (문서 관련 변경이 있을 경우)


### 📸 스크린샷
<!-- 테스트 완료 스크린샷을 작성해주시면 되요! -->

<img width="1217" height="446" alt="image" src="https://github.com/user-attachments/assets/0da665c3-a0dd-4d18-ab1e-aee5c1a58226" />

### 📣 리뷰어에게 전달할 내용
<!-- 혹시 저에게 전달하고 싶은 사항이 있으신가요?? 중점적인 부분만 전달해주시면 빠른 판단과 검토가 가능해요!! -->
